### PR TITLE
test for invalid bytes

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,3 +43,7 @@ end
         do_testfile(f)
     end
 end
+
+@testset "invalid chars" begin
+    @test striprtf(raw"{\rtf1\ansi\ansicpg0 T\'e4st}") == "T\xe4st" # invalid bytes preserved
+end


### PR DESCRIPTION
Test for https://github.com/joshy/striprtf/issues/46 — unlike the upstream package, StripRTF.jl currently doesn't have a variety of error-handling modes.  We simply preserve invalid bytes as-is (at least for now).

(It might be a good idea to replace these with `�` in the future, similar to the upstream package in the `errors='replace'` mode, lest an invalid RTF file insert some unintended UTF-8 encoded Unicode char?  Not sure if the https://github.com/JuliaStrings/StringEncodings.jl package supports this?  Its README says "It is not yet possible to ignore such characters or to replace them with a placeholder" so we may be stuck at the moment.)